### PR TITLE
Example: First difference GP on logic

### DIFF
--- a/stan/inc2prev_antibodies.stan
+++ b/stan/inc2prev_antibodies.stan
@@ -84,7 +84,7 @@ transformed parameters {
   gp = update_gp(PHI, M, L, alpha, rho, eta, 0);
   // relative probability of infection
   infections[1] = inv_logit(inc_init);
-  infections[2:t] = inv_logit(inc_init + sum(gp));
+  infections[2:t] = inv_logit(inc_init + cumulative_sum(gp));
   // calculate detectable cases
   dcases = convolve(infections, prob_detect);
   // calculate observed detectable cases


### PR DESCRIPTION
This is an example of using a first differenced GP with a logit link. The behaviour of this should be to revert to 0 growth outside the support of the lengthscale. (*Note: written using `github.dev` so it really is just an example*).