### PR TITLE
Feature: forecasting

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -57,13 +57,9 @@ RUN Rscript -e 'devtools::install_github("mdlincoln/docthis")'
 # install precommit
 RUN Rscript -e 'devtools::install_github("lorenzwalthert/precommit")'
 
-# install cmdstanr
 RUN Rscript -e 'devtools::install_github("stan-dev/cmdstanr")'
-
 # install cmdstan
-RUN mkdir -p /home/vscode/.cmdstan
-RUN Rscript -e 'cmdstanr::install_cmdstan("/home/vscode/.cmdstan")'
-RUN chmod -R ugo+rw /home/vscode/.cmdstan
+RUN Rscript -e "cmdstanr::install_cmdstan()"
 
 # install dependencies
 COPY DESCRIPTION /tmp/package/DESCRIPTION

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/r
 {
-	"name": "R (Community)",
+	"name": "inc2prev",
 	"image": "ghcr.io/epiforecasts/inc2prev:master",
 	"shutdownAction": "none",
 	// Set *default* container specific settings.json values on container create.

--- a/R/model.R
+++ b/R/model.R
@@ -9,7 +9,7 @@ i2p_gp_tune_model <- function(path) {
 
 # define required stan data
 i2p_data <- function(prev, ab, vacc, init_ab,
-                     prob_detectable, ut = 14,
+                     prob_detectable, ut = 14, ht = 0,
                      init_cum_infections = c(0, 0),
                      inf_ab_delay = c(rep(0, 7 * 4), rep(1 / 7, 7)),
                      vacc_ab_delay = c(rep(0, 7 * 4), rep(1 / 7, 7)),
@@ -64,6 +64,7 @@ i2p_data <- function(prev, ab, vacc, init_ab,
     model_start_date <- min(prev$start_date)
     model_end_date <- max(prev$end_date)
   }
+  model_end_date <- model_end_date + days(ht)
   all_dates <- seq(model_start_date - days(ut), model_end_date, by = "days")
   prev[, `:=`(
     stime = as.integer(start_date - model_start_date),

--- a/R/model.R
+++ b/R/model.R
@@ -9,7 +9,7 @@ i2p_gp_tune_model <- function(path) {
 
 # define required stan data
 i2p_data <- function(prev, ab, vacc, init_ab,
-                     prob_detectable, ut = 14, ht = 0,
+                     prob_detectable, unobserved_time = 14, horizon = 0,
                      init_cum_infections = c(0, 0),
                      inf_ab_delay = c(rep(0, 7 * 4), rep(1 / 7, 7)),
                      vacc_ab_delay = c(rep(0, 7 * 4), rep(1 / 7, 7)),
@@ -64,8 +64,8 @@ i2p_data <- function(prev, ab, vacc, init_ab,
     model_start_date <- min(prev$start_date)
     model_end_date <- max(prev$end_date)
   }
-  model_end_date <- model_end_date + days(ht)
-  all_dates <- seq(model_start_date - days(ut), model_end_date, by = "days")
+  model_end_date <- model_end_date + days(horizon)
+  all_dates <- seq(model_start_date - days(unobserved_time), model_end_date, by = "days")
   prev[, `:=`(
     stime = as.integer(start_date - model_start_date),
     etime = as.integer(end_date - model_start_date)
@@ -106,11 +106,11 @@ i2p_data <- function(prev, ab, vacc, init_ab,
     by = time
   ]
   # define baseline incidence
-  baseline_inc <- prev$prev[1] * prob_detectable$mean[ut]
+  baseline_inc <- prev$prev[1] * prob_detectable$mean[unobserved_time]
 
   # build stan data
   dat <- list(
-    ut = ut,
+    ut = unobserved_time,
     t = length(all_dates),
     obs = length(prev$prev),
     prev = prev$prev,

--- a/R/model.R
+++ b/R/model.R
@@ -65,7 +65,9 @@ i2p_data <- function(prev, ab, vacc, init_ab,
     model_end_date <- max(prev$end_date)
   }
   model_end_date <- model_end_date + days(horizon)
-  all_dates <- seq(model_start_date - days(unobserved_time), model_end_date, by = "days")
+  all_dates <- seq(
+    model_start_date - days(unobserved_time), model_end_date, by = "days"
+  )
   prev[, `:=`(
     stime = as.integer(start_date - model_start_date),
     etime = as.integer(end_date - model_start_date)

--- a/R/postprocess.R
+++ b/R/postprocess.R
@@ -40,7 +40,7 @@ i2p_add_date <- function(dt, prev, ab, data) {
         name == "est_prev", prev$date[index],
         name == "est_ab", ab$date[index],
         name == "r", index + start_date - ut,
-        name == "R", index - 1 + start_date
+        name == "R", index - ut + start_date
       )
     ]
   )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -67,6 +67,7 @@ Bt
 BTv
 Ɓ
 Č
+caclulate
 callr
 cB
 cdf
@@ -190,6 +191,7 @@ IǶ
 Ijs
 ikuyadeu
 indepedent
+infs
 init
 inv
 io
@@ -231,6 +233,7 @@ libssl
 libv
 libxml
 libxt
+linf
 linter
 linters
 linux
@@ -241,6 +244,7 @@ lP
 Lp
 lshtm
 lV
+lvacc
 lw
 lz
 ͕M

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -58,7 +58,9 @@ BN
 BNS
 BNuD
 bo
+bocharov
 bP
+bracketedPaste
 Bsh
 bT
 Bt
@@ -77,6 +79,7 @@ cmdstanr
 CmdStanR
 CmdStanR’s
 cN
+config
 conv
 convolve
 convolved
@@ -131,6 +134,8 @@ fH
 fI
 fns
 forcats
+formulahendry
+forwardPorts
 fQ
 Fq
 FQ
@@ -142,6 +147,7 @@ Fzo
 gC
 ggplot
 GH
+ghcr
 gi
 GID
 github
@@ -182,6 +188,7 @@ ig
 IǶ
 ǐI
 Ijs
+ikuyadeu
 indepedent
 init
 inv
@@ -189,6 +196,7 @@ io
 ir
 Iu
 iV
+ivan
 iZb
 JA
 Jd
@@ -197,6 +205,7 @@ JH
 jk
 jM
 jQ
+json
 jx
 JӖ
 jﴑ
@@ -224,6 +233,7 @@ libxml
 libxt
 linter
 linters
+linux
 Lk
 lN
 lorenzwalthert
@@ -245,6 +255,7 @@ microsoft
 mkdir
 modelled
 mS
+mutantdino
 ņ
 ncpus
 Nk
@@ -275,6 +286,7 @@ oPM
 ORCID
 ot
 Ov
+overrideName
 ۭp
 ۭP
 PÃ
@@ -294,6 +306,7 @@ PN
 pO
 positivity
 posivitiy
+postCreateCommand
 postitivity
 postive
 postprocessing
@@ -327,10 +340,12 @@ q탫
 Ȑ
 Ȓ
 ra
+README
 readr
 readxl
 refname
 reimplementation
+resourcemonitor
 rf
 rl
 rng
@@ -342,6 +357,7 @@ rpfD
 rQH
 Rscript
 rstan
+rterm
 RtmpI
 rvest
 rw
@@ -352,11 +368,13 @@ sam
 SAV
 sb
 sd
+searking
 sebastian
 seroconversion
 seroconversions
 seroconvert
 sH
+shutdownAction
 sK
 skipinstalled
 sN
@@ -390,6 +408,7 @@ tM
 tMH
 tmp
 tmux
+tomoki
 toolchain
 tp
 tq
@@ -419,9 +438,11 @@ uLH
 uo
 uPt
 Uq
+useHttpgd
 usermod
 USH
 usin
+usr
 ut
 Uv
 UX
@@ -442,6 +463,7 @@ wKk
 wLH
 wn
 Wn
+wordSeparators
 WPEm
 wr
 WR

--- a/scripts/simple-example.R
+++ b/scripts/simple-example.R
@@ -72,9 +72,14 @@ fit
 prev_plot <- plot_prev(
   fit$summary[[1]], fit$samples[[1]][sample <= 100],
   joint_data$prevalence[[1]]
-) +
-  scale_y_continuous(tran = scales::logit_trans())
+)
 ggsave("figures/prev.png", prev_plot, width = 9, height = 6)
+
+
+prev_logit_plot <- prev_plot +
+  scale_y_continuous(tran = scales::logit_trans())
+ggsave("figures/prev-logit.png", prev_logit_plot, width = 9, height = 6)
+
 
 # plot modelled and observed (but also modelled) antibodies
 ab_plot <- plot_prev(

--- a/scripts/simple-example.R
+++ b/scripts/simple-example.R
@@ -63,7 +63,7 @@ fit <- incidence(
   ),
   prob_detect = prob_detect, parallel_chains = 2, iter_warmup = 250,
   chains = 2, model = mod, adapt_delta = 0.8, max_treedepth = 12,
-  data_args = list(gp_tune_model = tune),
+  data_args = list(gp_tune_model = tune, ht = 14),
   keep_fit = TRUE
 )
 fit
@@ -72,13 +72,16 @@ fit
 prev_plot <- plot_prev(
   fit$summary[[1]], fit$samples[[1]][sample <= 100],
   joint_data$prevalence[[1]]
-)
+) +
+  scale_y_continuous(tran = scales::logit_trans())
 ggsave("figures/prev.png", prev_plot, width = 9, height = 6)
 
 # plot modelled and observed (but also modelled) antibodies
-ab_plot <- plot_ab(
+ab_plot <- plot_prev(
   fit$summary[[1]], fit$samples[[1]][sample <= 100],
-  joint_data$antibodies[[1]]
+  joint_data$antibodies[[1]],
+  data_source = "ONS Antibodies", observed = "est_ab",
+  modelled = "dab"
 )
 ggsave("figures/ab.png", ab_plot, width = 9, height = 6)
 

--- a/scripts/simple-example.R
+++ b/scripts/simple-example.R
@@ -63,7 +63,7 @@ fit <- incidence(
   ),
   prob_detect = prob_detect, parallel_chains = 2, iter_warmup = 250,
   chains = 2, model = mod, adapt_delta = 0.8, max_treedepth = 12,
-  data_args = list(gp_tune_model = tune, ht = 14),
+  data_args = list(gp_tune_model = tune, horizon = 14),
   keep_fit = TRUE
 )
 fit

--- a/scripts/simple-example.R
+++ b/scripts/simple-example.R
@@ -75,11 +75,9 @@ prev_plot <- plot_prev(
 )
 ggsave("figures/prev.png", prev_plot, width = 9, height = 6)
 
-
 prev_logit_plot <- prev_plot +
   scale_y_continuous(tran = scales::logit_trans())
 ggsave("figures/prev-logit.png", prev_logit_plot, width = 9, height = 6)
-
 
 # plot modelled and observed (but also modelled) antibodies
 ab_plot <- plot_prev(
@@ -89,7 +87,6 @@ ab_plot <- plot_prev(
   modelled = "dab"
 )
 ggsave("figures/ab.png", ab_plot, width = 9, height = 6)
-
 
 # pairs plot
 stanfit <- read_stan_csv(fit$fit[[1]]$output_files())

--- a/stan/inc2prev_antibodies.stan
+++ b/stan/inc2prev_antibodies.stan
@@ -86,7 +86,7 @@ transformed parameters {
   // calculate detectable cases
   dcases = convolve(infections, prob_detect);
   // calculate observed detectable cases
-  od cases = observed_in_window(dcases, prev_stime, prev_etime, ut, obs);
+  odcases = observed_in_window(dcases, prev_stime, prev_etime, ut, obs);
   //calculate infections with potential to have antibodies
   infs_with_potential_abs = convolve(infections, inf_ab_delay);
   // calculate detectable antibodies

--- a/stan/inc2prev_antibodies.stan
+++ b/stan/inc2prev_antibodies.stan
@@ -86,8 +86,8 @@ transformed parameters {
   // calculate detectable cases
   dcases = convolve(infections, prob_detect);
   // calculate observed detectable cases
-  odcases = observed_in_window(dcases, prev_stime, prev_etime, ut, obs);
-  // caclulate infections with potential to have antibodies
+  od cases = observed_in_window(dcases, prev_stime, prev_etime, ut, obs);
+  //calculate infections with potential to have antibodies
   infs_with_potential_abs = convolve(infections, inf_ab_delay);
   // calculate detectable antibodies
   dab = detectable_antibodies(infs_with_potential_abs, vacc_with_ab, beta,

--- a/stan/inc2prev_antibodies.stan
+++ b/stan/inc2prev_antibodies.stan
@@ -128,7 +128,7 @@ model {
 
 generated quantities {
   vector[t - ut] R;
-  vector[t - 1] r;
+  vector[t - ut] r;
   real est_prev[obs];
   real est_ab[ab_obs];
   // sample estimated prevalence
@@ -140,5 +140,5 @@ generated quantities {
   // calculate Rt using infections and generation time
   R = calculate_Rt(infections, ut, gtm_sample, gtsd_sample, gtmax, 1);
   // calculate growth
-  r = calculate_growth(infections, 1);
+  r = calculate_growth(infections, ut);
 }


### PR DESCRIPTION
Adds support for out of sample forecasting by extending the maximum observed date. This PR also brings output growth estimates into line with output Rt estimates (so both cut-off initial burn in period. Finally it fixes plotting in the example script (due to the removal of `plot_ab` and regenerates plots with data in master (shifting to a logit scale for prevalence due to recent surge making the rest of the plot impossible to see). 