### PR TITLE
Differences model fixes

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -136,22 +136,28 @@ i2p_data <- function(prev, ab, vacc, init_ab,
     ab_likelihood = as.numeric(ab_likelihood)
   )
 
-  dat <- c(dat, list(
-    ab_obs = ifelse(!is.null(ab), length(ab$prev), 0),
-    ab = ifelse(!is.null(ab), ab$prev, 1),
-    ab_sd2 = ifelse(!is.null(ab), ab$sd^2, 1),
-    ab_stime = ifelse(!is.null(ab), ab$stime, 1),
-    ab_etime = ifelse(!is.null(ab), ab$etime, 1)
-  ))
-
-  dat <- c(dat, list(
-      vacc = ifelse(!is.null(ab), vacc$vaccinated, 1)
+  dat$ab_obs <- ifelse(is.null(ab), 0L, length(ab$prev))
+  if (!is.null(ab)) {
+    dat <- c(dat, list(
+      ab = ab$prev,
+      ab_sd2 = ab$sd^2,
+      ab_stime = ab$stime,
+      ab_etime = ab$etime,
+      init_ab_mean = init_ab$prev,
+      init_ab_sd = init_ab$sd,
+      vacc = vacc$vaccinated
     ))
-
-  dat <- c(dat, list(
-      init_ab_mean = ifelse(!is.null(ab), init_ab$prev, 1),
-      init_ab_sd = ifelse(!is.null(ab), init_ab$sd, 1)
-  ))
+  } else {
+    dat <- c(dat, list(
+      ab = numeric(0),
+      ab_sd2 = numeric(0),
+      ab_stime = numeric(0),
+      ab_etime = numeric(0),
+      init_ab_mean = numeric(0),
+      init_ab_sd = numeric(0),
+      vacc = numeric(0)
+    ))
+  }
 
   # gaussian process parameters
   dat$M <- ceiling(dat$t * gp_m)
@@ -194,7 +200,7 @@ i2p_inits <- function(dat) {
       init_list$init_growth <- array(rnorm(dat$diff_order, 0, 0.01))
     }
 
-    if (!is.null(dat[["ab"]])) {
+    if (dat$ab_obs > 0) {
       init_list <- c(init_list, list(
         beta = array(inv_logit(rnorm(1, -2, 0.4))),
         gamma = array(inv_logit(rnorm(2, -9, 0.4))),

--- a/stan/inc2prev.stan
+++ b/stan/inc2prev.stan
@@ -14,13 +14,13 @@ data {
   int ab_obs; // number of antibody prevalence observations
   vector[obs] prev; // observed positivity prevalence
   vector[obs] prev_sd2; // squared standard deviation of observed positivity prevalence
-  vector[max(ab_obs, 1)] ab; // observed antibody posivitiy prevalence
-  vector[max(ab_obs, 1)] ab_sd2; // squared standard deviation of observed antibody prevalence
+  vector[ab_obs] ab; // observed antibody posivitiy prevalence
+  vector[ab_obs] ab_sd2; // squared standard deviation of observed antibody prevalence
   int prev_stime[obs]; // starting times of positivity prevalence observations
   int prev_etime[obs]; // end times of positivity prevalence observations
-  int ab_stime[max(ab_obs, 1)]; // starting times of antibody prevalence observations
-  int ab_etime[max(ab_obs, 1)]; // end times of antibody prevalence observations
-  vector[ab_obs ? t : 1] vacc; // vaccinations
+  int ab_stime[ab_obs]; // starting times of antibody prevalence observations
+  int ab_etime[ab_obs]; // end times of antibody prevalence observations
+  vector[ab_obs] vacc; // vaccinations
   int pbt; // maximum detection time
   vector[pbt] prob_detect_mean; // at each time since infection, probability of detection
   vector[pbt] prob_detect_sd; // at each time since infection, tandard deviation of probability of detection
@@ -33,8 +33,8 @@ data {
   real gtsd[2]; // mean and sd of the sd of the generation time
   int gtmax; // maximum number of days to consider for the generation time
   real init_inc_mean ; // Mean initial/mean incidence (logit)
-  real init_ab_mean; // mean estimate of initial antibody prevalence
-  real init_ab_sd;   // sd of estimate of initial antibody prevalence
+  real init_ab_mean[ab_obs > 0 ? 1 : 0]; // mean estimate of initial antibody prevalence
+  real init_ab_sd[ab_obs > 0 ? 1 : 0]; // sd of estimate of initial antibody prevalence
   real pbeta[2]; // Mean and sd for prior proportion that don't seroconvert
   real pgamma_mean[2]; // Means for prior infection and vaccine waning
   real pgamma_sd[2]; // Sds for prior infection and vaccine waning
@@ -136,7 +136,7 @@ model {
 
   // Priors for antibody model
   if (ab_obs) {
-    init_dab ~ normal(init_ab_mean, init_ab_sd);
+    init_dab ~ normal(init_ab_mean[1], init_ab_sd[1]);
     logit(beta) ~ normal(pbeta[1], pbeta[2]);
     logit(gamma) ~ normal(pgamma_mean, pgamma_sd); 
     logit(delta) ~ normal(pdelta, pdelta); 


### PR DESCRIPTION
The model in https://github.com/epiforecasts/inc2prev/pull/18 did not work out of the box for me because of variable size mismatches and some other niggles. These are the changes I had to make to get it work.

As a more general point I wasn't clear on the rationale for some of the parameter values depending on whether antibody data was included or not. In my mind there are the following use cases:

1.  estimate incidence from prevalence, ignore antibodies
2. estimate incidence from prevalence, ignore antibodies, estimate antibodies from priors and vaccination data
3. estimate incidence and antibody parameters from prevalence,  antibodies and vaccination
4. estimate incidence and antibody parameters from multiple datasets on prevalence, antibodies and vaccination where antibody data is only available for some of the datasets

1 could be a sub-model of 2 and 3 a sub-model of 4. What's implemented no is (1) and (3), (2) would probably be easy to add and (4) a good thing to aim for.