### PR TITLE
Replace `load_all` with package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ Rscript data-raw/update-ab.R
 
 ## Reproducing the estimates
 
-Estimates provided here can be generated using the `scripts/estimate.R` script.
+Estimates provided here can be generated using the `scripts/estimate.R` script. Before running this, the `inc2prev` package contained in this repository needs to be installed, e.g. using
+
+```{r}
+remotes::install_github("epiforecasts/inc2prev")
+```
+
 The estimates shown in the plots above were generated using
 
 ```{sh}

--- a/scripts/analyse.R
+++ b/scripts/analyse.R
@@ -37,9 +37,6 @@ local <- !is.null(opts$local) && opts$local
 age <- !is.null(opts$age) && opts$age
 variants <- !is.null(opts$variants) && opts$variants
 
-## Get tools
-devtools::load_all()
-
 if (local) {
   suffix <- "_local"
 } else if (regional) {

--- a/scripts/estimate.R
+++ b/scripts/estimate.R
@@ -57,9 +57,6 @@ start_date <- as.Date(opts$start_date)
 weekly <- !is.null(opts$weekly) && opts$weekly
 gp_frac <- ifelse(is.null(opts$gp_frac), 0.3, as.numeric(opts$gp_frac))
 
-## Get tools
-devtools::load_all()
-
 # Load prevalence data and split by location
 data <- read_cis(nhse_regions = nhse)
 

--- a/scripts/plot_data.r
+++ b/scripts/plot_data.r
@@ -4,9 +4,6 @@ library(ggplot2)
 library(socialmixr)
 library(dplyr)
 
-## Get tools
-devtools::load_all()
-
 prev <- read_cis()
 
 p <- ggplot(prev %>%

--- a/scripts/simple-example.R
+++ b/scripts/simple-example.R
@@ -20,8 +20,6 @@ library(cowplot)
 # Test target
 example_var <- "England"
 end_date <- "2021-11-01"
-## Get tools
-devtools::load_all()
 
 # Load prevalence data and split by location
 prev <- read_cis() %>%


### PR DESCRIPTION
The current approach of using `devtools::load_all` to source the contents of `R` causes [problems when using parallelisation](https://github.com/epiforecasts/inc2prev/issues/35).

This removes the corresponding lines and adds instructions for package install to the README.